### PR TITLE
Terraform Dependency Lock

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/digitalocean/digitalocean" {
+  version     = "2.21.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:gndflVS5/+cwQbVVI6NwwB3dYK7W2QkmZuWmFBH/0tI=",
+    "zh:122a4e7aa7315be52c484fa9b8e8681a42ad17e1f892ca17d6aeb575902df078",
+    "zh:192f9428d965d1a5d2629e6ec1c238c6815601fbc909f905bf94ff9359ba88f6",
+    "zh:20d88900cd24e9c05e2addeeb9fd5df285fba928d5f9981128352a6089fcec88",
+    "zh:30eb650c04e4c6ab0b06549a345dacdfaf5597f24e916ed82cad798a546783e6",
+    "zh:33864a8bc3f02507397d36bc5bf21ad1be11c188d2d0d45fe19063d0f949ff49",
+    "zh:34431ea6fe25e734ed851595f622ff848c325fbf2f799d85a6cfcadedc1e9063",
+    "zh:4be9ee1d632352504541d3629ce583e2b89ab9e5eb6a9d6547d37eb1c02dc341",
+    "zh:723436531aaec6a7d651b15857194993baee6e59d7b1b8c22176ee44065de905",
+    "zh:7305edf6305f3c0ba945509e679655d2b7c082f21723e2bd415c8f1f161a1a97",
+    "zh:acd2124cb1c604351f9482d47ab9a16a1887b8d9df049c8da0d0e3791326404d",
+    "zh:af6745bb9096a52e2570a758b55fd0a746b70d4bb04ba09ee33ab7dd63e87337",
+    "zh:b676c58bbfd08bd3960ed78740a23ed17d959ac0348cab08ad34aaeaff952c7d",
+    "zh:bfa739ac5fea3f89d9c403be91179729490370ed19b735070c9659e9265718aa",
+    "zh:c1d5a0d0995fddf0df03f1da49de9531ab45138cf0b24e67c45f23a38ba91c33",
+    "zh:cac52e76829a1fc01e165c4a66854b94b2813a21d392f6bddfacbba7edfd4f77",
+    "zh:d55cdd70b89e7e9cd674c0f39cdef93dd0ace1d361bbae65583df9defb7d4725",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.2.3"
+  hashes = [
+    "h1:aWp5iSUxBGgPv1UnV5yag9Pb0N+U1I0sZb38AXBFO8A=",
+    "zh:04f0978bb3e052707b8e82e46780c371ac1c66b689b4a23bbc2f58865ab7d5c0",
+    "zh:6484f1b3e9e3771eb7cc8e8bab8b35f939a55d550b3f4fb2ab141a24269ee6aa",
+    "zh:78a56d59a013cb0f7eb1c92815d6eb5cf07f8b5f0ae20b96d049e73db915b238",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8aa9950f4c4db37239bcb62e19910c49e47043f6c8587e5b0396619923657797",
+    "zh:996beea85f9084a725ff0e6473a4594deb5266727c5f56e9c1c7c62ded6addbb",
+    "zh:9a7ef7a21f48fabfd145b2e2a4240ca57517ad155017e86a30860d7c0c109de3",
+    "zh:a63e70ac052aa25120113bcddd50c1f3cfe61f681a93a50cea5595a4b2cc3e1c",
+    "zh:a6e8d46f94108e049ad85dbed60354236dc0b9b5ec8eabe01c4580280a43d3b8",
+    "zh:bb112ce7efbfcfa0e65ed97fa245ef348e0fd5bfa5a7e4ab2091a9bd469f0a9e",
+    "zh:d7bec0da5c094c6955efed100f3fe22fca8866859f87c025be1760feb174d6d9",
+    "zh:fb9f271b72094d07cef8154cd3d50e9aa818a0ea39130bc193132ad7b23076fd",
+  ]
+}


### PR DESCRIPTION
Added the .terraform.lock.hcl file. The terraform documentation states that this file must be included in the version control repository to enable the discussion of possible changes related to external dependencies via code review, as well as possible discussions and changes in the configuration itself.